### PR TITLE
Extract only requested callback event fields

### DIFF
--- a/gui_builder/widgets/wx_widgets.py
+++ b/gui_builder/widgets/wx_widgets.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Dict,
     Generic,
     List,
@@ -150,16 +151,21 @@ def case_to_underscore(s: str) -> str:
 UNWANTED_ATTRIBUTES = {"GetLoggingOff", "GetClientData", "GetClientObject"}
 
 
-def extract_event_data(event: wx.Event) -> Dict[str, Any]:
+def extract_event_data(
+    event: wx.Event, requested_names: Optional[Collection[str]] = None
+) -> Dict[str, Any]:
     event_args = {}
+    extract_all = requested_names is None
     for attribute_name in dir(event):
         if (
             attribute_name.startswith("Get")
             and attribute_name not in UNWANTED_ATTRIBUTES
         ):
             translated_name = case_to_underscore(attribute_name[3:])
-            event_args[translated_name] = getattr(event, attribute_name)()
-    event_args["event"] = event
+            if extract_all or translated_name in requested_names:
+                event_args[translated_name] = getattr(event, attribute_name)()
+    if extract_all or "event" in requested_names:
+        event_args["event"] = event
     return event_args
 
 
@@ -188,11 +194,12 @@ def callback_wrapper(
                 a.insert(0, self)
         if has_kwargs:
             k.update(extract_event_data(evt))
+        requested_event_names = set()
         if argspec.defaults is not None:
-            extracted = extract_event_data(evt)
-            for arg in argspec.args:
-                if arg in extracted:
-                    k[arg] = extracted[arg]
+            requested_event_names.update(argspec.args[-len(argspec.defaults) :])
+        requested_event_names.update(getattr(argspec, "kwonlyargs", ()))
+        if requested_event_names:
+            k.update(extract_event_data(evt, requested_event_names))
         try:
             result = callback(*a, **k)
         except Exception as e:

--- a/gui_builder/widgets/wx_widgets.py
+++ b/gui_builder/widgets/wx_widgets.py
@@ -192,13 +192,12 @@ def callback_wrapper(
                 self = None
             if self is not None:
                 a.insert(0, self)
-        if has_kwargs:
-            k.update(extract_event_data(evt))
-        requested_event_names = set()
-        if argspec.defaults is not None:
-            requested_event_names.update(argspec.args[-len(argspec.defaults) :])
+        requested_event_names = set(argspec.args)
+        requested_event_names.discard("self")
         requested_event_names.update(getattr(argspec, "kwonlyargs", ()))
-        if requested_event_names:
+        if has_kwargs and not requested_event_names:
+            k.update(extract_event_data(evt))
+        elif requested_event_names:
             k.update(extract_event_data(evt, requested_event_names))
         try:
             result = callback(*a, **k)

--- a/test_callback_event_data.py
+++ b/test_callback_event_data.py
@@ -1,0 +1,68 @@
+from gui_builder.widgets.wx_widgets import callback_wrapper
+
+
+class LazyEvent:
+    def __init__(self):
+        self.calls = []
+        self.skipped = False
+        self.stopped = False
+
+    def GetSelection(self):
+        self.calls.append("GetSelection")
+        return 7
+
+    def GetString(self):
+        self.calls.append("GetString")
+        raise AssertionError("unrequested getter was called")
+
+    def Skip(self):
+        self.skipped = True
+
+    def StopPropagation(self):
+        self.stopped = True
+
+
+class WidgetStub:
+    def find_event_target(self, callback):
+        raise ValueError("callback is not attached to this widget")
+
+
+def test_callback_wrapper_only_reads_requested_defaulted_event_fields():
+    event = LazyEvent()
+    received = {}
+
+    def callback(selection=None):
+        received["selection"] = selection
+
+    callback_wrapper(WidgetStub(), callback)(event)
+
+    assert received == {"selection": 7}
+    assert event.calls == ["GetSelection"]
+    assert event.skipped is True
+    assert event.stopped is False
+
+
+def test_callback_wrapper_event_argument_does_not_read_event_getters():
+    event = LazyEvent()
+    received = {}
+
+    def callback(event=None):
+        received["event"] = event
+
+    callback_wrapper(WidgetStub(), callback)(event)
+
+    assert received == {"event": event}
+    assert event.calls == []
+
+
+def test_callback_wrapper_only_reads_requested_keyword_only_event_fields():
+    event = LazyEvent()
+    received = {}
+
+    def callback(*, selection=None):
+        received["selection"] = selection
+
+    callback_wrapper(WidgetStub(), callback)(event)
+
+    assert received == {"selection": 7}
+    assert event.calls == ["GetSelection"]

--- a/test_callback_event_data.py
+++ b/test_callback_event_data.py
@@ -1,3 +1,81 @@
+import sys
+import types
+
+
+class WxStub(types.ModuleType):
+    def __getattr__(self, name):
+        value = type(name, (), {})
+        setattr(self, name, value)
+        return value
+
+
+def install_wx_stub():
+    wx = WxStub("wx")
+    wx.__path__ = []
+    for name in (
+        "Window",
+        "EvtHandler",
+        "Event",
+        "PyEventBinder",
+        "StaticText",
+        "Gauge",
+        "Control",
+        "ControlWithItems",
+        "TextCtrl",
+        "Panel",
+        "Slider",
+        "ListCtrl",
+        "TopLevelWindow",
+        "Dialog",
+        "Frame",
+        "MDIParentFrame",
+        "MDIChildFrame",
+        "Notebook",
+        "MenuBar",
+        "Menu",
+        "MenuItem",
+    ):
+        setattr(wx, name, type(name, (), {}))
+    for index, name in enumerate(
+        (
+            "ID_OK",
+            "ID_APPLY",
+            "ID_CANCEL",
+            "ID_CLOSE",
+            "ID_FIND",
+            "ID_YES",
+            "ID_NO",
+            "ID_ANY",
+        ),
+        start=1,
+    ):
+        setattr(wx, name, index)
+
+    wx_lib = types.ModuleType("wx.lib")
+    intctrl = types.ModuleType("wx.lib.intctrl")
+    intctrl.IntCtrl = type("IntCtrl", (), {})
+    sized_controls = types.ModuleType("wx.lib.sized_controls")
+    sized_controls.SizedDialog = type("SizedDialog", (), {})
+    sized_controls.SizedPanel = type("SizedPanel", (), {})
+    sized_controls.SizedFrame = type("SizedFrame", (), {})
+    calendar = types.ModuleType("wx.lib.calendar")
+    adv = WxStub("wx.adv")
+    adv.__path__ = []
+    wx.adv = adv
+
+    sys.modules.setdefault("wx", wx)
+    sys.modules.setdefault("wx.lib", wx_lib)
+    sys.modules.setdefault("wx.lib.intctrl", intctrl)
+    sys.modules.setdefault("wx.lib.sized_controls", sized_controls)
+    sys.modules.setdefault("wx.lib.calendar", calendar)
+    sys.modules.setdefault("wx.adv", adv)
+
+
+try:
+    import wx  # noqa: F401
+except ModuleNotFoundError:
+    install_wx_stub()
+
 from gui_builder.widgets.wx_widgets import callback_wrapper
 
 

--- a/test_callback_event_data.py
+++ b/test_callback_event_data.py
@@ -133,6 +133,20 @@ def test_callback_wrapper_event_argument_does_not_read_event_getters():
     assert event.calls == []
 
 
+def test_callback_wrapper_named_event_with_kwargs_does_not_read_event_getters():
+    event = LazyEvent()
+    received = {}
+
+    def callback(event=None, **kwargs):
+        received["event"] = event
+        received["kwargs"] = kwargs
+
+    callback_wrapper(WidgetStub(), callback)(event)
+
+    assert received == {"event": event, "kwargs": {}}
+    assert event.calls == []
+
+
 def test_callback_wrapper_only_reads_requested_keyword_only_event_fields():
     event = LazyEvent()
     received = {}


### PR DESCRIPTION
@
## Summary

Makes wxPython event-data extraction lazy. Previously `extract_event_data` called **every** `Get*` getter on an event and built a full dict on every callback invocation. Now it accepts an optional `requested_names` and only calls the getters the callback actually names (positional args minus `self`, plus keyword-only args).

## Why

Calling every getter is wasteful and, worse, can have side effects or raise — a callback that only wants `selection` should not trigger `GetString()` etc. The new tests encode this with a `LazyEvent` whose unrequested getters raise if touched.

## Behavior

- `def cb(self, selection=None)` → only `GetSelection()` is called.
- `def cb(self, *, selection=None)` → keyword-only args are honored.
- `def cb(self, event=None)` → receives the raw event, no getters called.
- `def cb(self, **kwargs)` (no named fields) → still receives the full event payload (unchanged).
- Positional non-default args (`def cb(self, x)`) are now filled — previously skipped, which could raise `TypeError`.

### Intentional change
`def cb(self, x=None, **kwargs)` now extracts only `x`; `**kwargs` is no longer filled with the entire payload. Named fields are treated as an explicit, narrow request. Pure-`**kwargs` callbacks are unaffected.

## Testing

New `test_callback_event_data.py` (4 tests, headless via a wx stub) — all pass:

```
uv run --with pytest python -m pytest test_callback_event_data.py
4 passed
```
@